### PR TITLE
Fix wrong APP_BASE_URL

### DIFF
--- a/demotemplate/settings.py
+++ b/demotemplate/settings.py
@@ -31,13 +31,12 @@ REMOTE = True if os.getenv('REMOTE', '').lower() == 'true' else False
 
 # Allow all host headers if this is running as a Heroku app.
 if REMOTE:
-    ALLOWED_HOSTS = ['*', 'oh-datauploader.herokuapp.com']
+    ALLOWED_HOSTS = ['*']
     print('REMOTE True')
-    APP_BASE_URL = 'https://oh-datauploader.herokuapp.com'
 else:
     ALLOWED_HOSTS = []
     print('REMOTE False')
-    APP_BASE_URL = os.getenv('APP_BASE_URL')
+APP_BASE_URL = os.getenv('APP_BASE_URL')
 
 
 # Open Humans configuration


### PR DESCRIPTION
Our project grant awardee @arvkevi had trouble getting this repo to run on GitHub. The problem is that if you set the `REMOTE` to true in `settings.py` it will also override the `APP_BASE_URL` that you set on `Heroku`. Thus the oauth2 handshake fails in deployment but not in local development.

That's super tricky to debug and took me a ridiculous number of print statements in the `views.py`. The PR here fixes it. 