### PR TITLE
middleware_classes are gone

### DIFF
--- a/demotemplate/settings.py
+++ b/demotemplate/settings.py
@@ -98,13 +98,8 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-]
-
-MIDDLEWARE_CLASSES = (
-    # Simplified static file serving.
-    # https://warehouse.python.org/project/whitenoise/
     'whitenoise.middleware.WhiteNoiseMiddleware'
-)
+]
 
 ROOT_URLCONF = 'demotemplate.urls'
 


### PR DESCRIPTION
In django 2.x there's no more `MIDDLEWARE_CLASSES` as in <2.0, thus the static delivery just fails. This fixes it.